### PR TITLE
Make the per-folder sync timeout configurable via MERON_SYNC_TIMEOUT

### DIFF
--- a/meron-core/src/engine.rs
+++ b/meron-core/src/engine.rs
@@ -838,9 +838,22 @@ pub fn cached_archive_folder_from_folders(
         .or_else(|| find_role_folder(folders, "archive", imap::looks_like_archive, current))
 }
 
-/// Per-folder cap for each piggybacked companion sync, so one slow mailbox
-/// can't hold the post-sync tail (and the emit that follows it) indefinitely.
-const COMPANION_SYNC_TIMEOUT: Duration = Duration::from_secs(30);
+/// Per-folder sync budget, shared by background syncs and each piggybacked
+/// companion sync so one slow mailbox can't hold the post-sync tail (and the
+/// emit that follows it) indefinitely. The 30s default suits direct IMAP
+/// servers; slow gateways (e.g. DavMail bridging Exchange EWS) can need more,
+/// so it can be overridden with `MERON_SYNC_TIMEOUT` (seconds).
+pub fn background_sync_timeout() -> Duration {
+    static TIMEOUT: std::sync::OnceLock<Duration> = std::sync::OnceLock::new();
+    *TIMEOUT.get_or_init(|| {
+        std::env::var("MERON_SYNC_TIMEOUT")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .filter(|&secs| secs > 0)
+            .map(Duration::from_secs)
+            .unwrap_or(Duration::from_secs(30))
+    })
+}
 
 /// The companion mailboxes (Sent, then Drafts) to piggyback onto a sync of
 /// another folder, each paired with its role label for the caller's logs.
@@ -889,7 +902,7 @@ pub async fn sync_companion_folders(
     let mut outcomes = Vec::new();
     for (role, companion) in companion_folders(sent, drafts) {
         let result = match tokio::time::timeout(
-            COMPANION_SYNC_TIMEOUT,
+            background_sync_timeout(),
             sync_messages(engine, account, &companion, limit),
         )
         .await

--- a/meron-core/src/engine.rs
+++ b/meron-core/src/engine.rs
@@ -838,20 +838,27 @@ pub fn cached_archive_folder_from_folders(
         .or_else(|| find_role_folder(folders, "archive", imap::looks_like_archive, current))
 }
 
+const DEFAULT_BACKGROUND_SYNC_TIMEOUT_SECS: u64 = 30;
+const MAX_BACKGROUND_SYNC_TIMEOUT_SECS: u64 = 24 * 60 * 60;
+
+fn parse_background_sync_timeout(value: Option<&str>) -> Duration {
+    value
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|&secs| (1..=MAX_BACKGROUND_SYNC_TIMEOUT_SECS).contains(&secs))
+        .map(Duration::from_secs)
+        .unwrap_or(Duration::from_secs(DEFAULT_BACKGROUND_SYNC_TIMEOUT_SECS))
+}
+
 /// Per-folder sync budget, shared by background syncs and each piggybacked
 /// companion sync so one slow mailbox can't hold the post-sync tail (and the
 /// emit that follows it) indefinitely. The 30s default suits direct IMAP
 /// servers; slow gateways (e.g. DavMail bridging Exchange EWS) can need more,
-/// so it can be overridden with `MERON_SYNC_TIMEOUT` (seconds).
+/// so it can be overridden with `MERON_SYNC_TIMEOUT` (seconds, up to one day).
 pub fn background_sync_timeout() -> Duration {
     static TIMEOUT: std::sync::OnceLock<Duration> = std::sync::OnceLock::new();
     *TIMEOUT.get_or_init(|| {
-        std::env::var("MERON_SYNC_TIMEOUT")
-            .ok()
-            .and_then(|v| v.parse::<u64>().ok())
-            .filter(|&secs| secs > 0)
-            .map(Duration::from_secs)
-            .unwrap_or(Duration::from_secs(30))
+        let value = std::env::var("MERON_SYNC_TIMEOUT").ok();
+        parse_background_sync_timeout(value.as_deref())
     })
 }
 
@@ -1793,8 +1800,8 @@ pub fn attach_html(message: &mut parse::Message, load_remote_images: bool) {
 mod tests {
     use super::{
         Pooled, cached_archive_folder_from_folders, cached_search_mail_page, companion_folders,
-        find_role_folder, limit_prefetch_uids, pool_return, pool_take, record_search_folder_result,
-        should_append_sent_copy, thread_gap_search_folders,
+        find_role_folder, limit_prefetch_uids, parse_background_sync_timeout, pool_return,
+        pool_take, record_search_folder_result, should_append_sent_copy, thread_gap_search_folders,
     };
     use rusqlite::{Connection, params};
     use std::collections::HashMap;
@@ -1960,6 +1967,24 @@ mod tests {
     #[test]
     pub fn companion_folders_empty_when_neither_resolves() {
         assert_eq!(companion_folders(None, None), Vec::new());
+    }
+
+    #[test]
+    pub fn background_sync_timeout_rejects_unsupported_values() {
+        assert_eq!(
+            parse_background_sync_timeout(Some("300")),
+            Duration::from_secs(300)
+        );
+        for value in [None, Some("0"), Some("invalid"), Some("86401")] {
+            assert_eq!(
+                parse_background_sync_timeout(value),
+                Duration::from_secs(30)
+            );
+        }
+        assert_eq!(
+            parse_background_sync_timeout(Some("18446744073709551615")),
+            Duration::from_secs(30)
+        );
     }
 
     #[test]

--- a/meron-core/src/main.rs
+++ b/meron-core/src/main.rs
@@ -35,7 +35,6 @@ use meron_core::{
 /// Shared, serialized writer so responses and events never interleave on stdout.
 type Writer = Arc<Mutex<Stdout>>;
 
-const BACKGROUND_SYNC_TIMEOUT: Duration = Duration::from_secs(30);
 const BACKGROUND_SYNC_RETRY_DELAY: Duration = if cfg!(test) {
     Duration::ZERO
 } else {
@@ -131,13 +130,14 @@ where
     if !can_attempt() {
         return Err(anyhow::Error::new(BackgroundSyncCancelled));
     }
-    let deadline = tokio::time::Instant::now() + BACKGROUND_SYNC_TIMEOUT;
+    let sync_timeout = background_sync_timeout();
+    let deadline = tokio::time::Instant::now() + sync_timeout;
     let first = tokio::time::timeout_at(deadline, operation()).await;
     let first_error = match first {
         Ok(Ok(value)) => return Ok(value),
         Ok(Err(error)) if is_transient_sync_error(&error) => error,
         Ok(Err(error)) => return Err(error),
-        Err(_) => anyhow::bail!("timed out after {}s", BACKGROUND_SYNC_TIMEOUT.as_secs()),
+        Err(_) => anyhow::bail!("timed out after {}s", sync_timeout.as_secs()),
     };
 
     eprintln!("meron-core: {label} failed, retrying: {first_error:#}");
@@ -147,7 +147,7 @@ where
     {
         return Err(first_error.context(format!(
             "retry budget exhausted after {}s",
-            BACKGROUND_SYNC_TIMEOUT.as_secs()
+            sync_timeout.as_secs()
         )));
     }
     if !can_attempt() {
@@ -161,7 +161,7 @@ where
         )),
         Err(_) => Err(first_error.context(format!(
             "retry timed out within the {}s sync budget",
-            BACKGROUND_SYNC_TIMEOUT.as_secs()
+            sync_timeout.as_secs()
         ))),
     }
 }

--- a/meron-core/src/main.rs
+++ b/meron-core/src/main.rs
@@ -115,8 +115,8 @@ impl std::fmt::Display for BackgroundSyncCancelled {
 impl std::error::Error for BackgroundSyncCancelled {}
 
 /// Retry a background read once when it fails for a recognizable transport
-/// reason. Both attempts share the old 30-second ceiling so a stuck sync does
-/// not hold its dedup key longer than before.
+/// reason. Both attempts share the configured per-folder ceiling so a stuck
+/// sync does not hold its dedup key indefinitely.
 async fn retry_background_sync<T, C, F, Fut>(
     label: &str,
     mut can_attempt: C,


### PR DESCRIPTION
## Problem

Both per-folder sync budgets — the background sync in `meron-core/src/main.rs` and the piggybacked Sent/Drafts companion sync in `meron-core/src/engine.rs` — are hardcoded at 30 seconds. Through a slow gateway such as DavMail bridging Exchange EWS (context: #20), or against a large mailbox, a first full folder sync cannot finish inside that budget. The sync times out, partial progress is discarded, and every retry starts from scratch, so the account loops on `sync INBOX: timed out after 30s` forever and never completes.

## Change

- A single shared helper in `engine.rs` reads `MERON_SYNC_TIMEOUT` (seconds) once via `OnceLock`, following the existing `MERON_MEDIA_CAP`/`MERON_KEYRING` env-var pattern.
- Both budgets (background sync and companion sync) use it.
- Unset, invalid, or zero values fall back to the current 30s, so behavior without the variable is unchanged.

## Verification

- `cargo test --bin meron-core background_sync` passes (4/4).
- Validated in practice against an on-premises Exchange server behind DavMail: with the default 30s the initial sync loops on timeouts indefinitely; with `MERON_SYNC_TIMEOUT=300` the full mailbox (inbox + companion folders) syncs to completion and steady-state incremental syncs then fit comfortably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)